### PR TITLE
fix: add ability to print file path

### DIFF
--- a/bashbox
+++ b/bashbox
@@ -3,7 +3,7 @@ cmdf=$1
 shift
 case $cmdf in
 --build)
-	echo 1684007392,213612
+	echo 1684795386.302176
 ;;
 arch)
 #!/usr/bin/env bash
@@ -3633,8 +3633,8 @@ realpath)
 
 for file in "$@"
 do
-	cd -P $file
-	echo $PWD
+	cd -P "${file%/*}" &&
+		echo "$PWD/${file##*/}"
 done
 ;;
 rev)

--- a/bin/realpath
+++ b/bin/realpath
@@ -4,6 +4,6 @@
 
 for file in "$@"
 do
-	cd -P $file
-	echo $PWD
+	cd -P "${file%/*}" &&
+		echo "$PWD/${file##*/}"
 done


### PR DESCRIPTION
to fix #4:

- [x] cd to the physical directory of the file instead of the file itself
- [x] print the path, including file name, only if cd was successful
- [x] quote the variables